### PR TITLE
Add trailing package declaration

### DIFF
--- a/enh-ruby-mode.el
+++ b/enh-ruby-mode.el
@@ -1082,3 +1082,5 @@ With ARG, do it that many times."
 (erm-reset)
 
 (provide 'enh-ruby-mode)
+
+;;; enh-ruby-mode.el ends here


### PR DESCRIPTION
This is to bring enh-ruby-mode in line with the correct package.el formatting.

See milkypostman/melpa#527 for more information.
