### PR TITLE
Can also be installed via Melpa

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -22,7 +22,7 @@ Syntax checking is also preformed.
 
 == Synopsis
    
-* Enhanced Ruby Mode is intallable via el-get, where its package name is enh-ruby-mode.    
+* Enhanced Ruby Mode is intallable via el-get and Melpa, where its package name is enh-ruby-mode.    
    
 * For manual installation, add the following file to your init file. 
 


### PR DESCRIPTION
This adds a mention of Melpa to the synopsis section, as el-get is not the only way to install the package.
