### PR TITLE
Update erm.rb to use environment ruby.

### DIFF
--- a/ruby/erm.rb
+++ b/ruby/erm.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby
+#!/usr/bin/env ruby
 
 class BufferStore
   def initialize


### PR DESCRIPTION
I am using rbenv to manage my rubies locally (inside a corporate environment with no sudo access). I am not actually sure this is even required any longer. At any rate this should not be using the system default ruby which, on Mac OS X 10.8.4, is still MRI 1.8.7.

This currently crashes the MELPA version with a set_encoding error.
