### PR TITLE
caddr and cdddr are not defined by default

### DIFF
--- a/enh-ruby-mode.el
+++ b/enh-ruby-mode.el
@@ -44,6 +44,8 @@
 ;;    (setq enh-ruby-program "(path-to-ruby1.9)/bin/ruby") ; so that still works if ruby points to ruby1.8
 ;;
 
+(require 'cl) ; for cdddr, caddr
+
 ;;; Variables:
 
 (defcustom enh-ruby-program "ruby"


### PR DESCRIPTION
In enh-ruby-mode.el, [caddr](https://github.com/zenspider/enhanced-ruby-mode/blob/2736dedbe315c21b5e75e5800a0c36be90496d65/enh-ruby-mode.el#L1013) and [cdddr](https://github.com/zenspider/enhanced-ruby-mode/blob/2736dedbe315c21b5e75e5800a0c36be90496d65/enh-ruby-mode.el#L1025) are used, but they are not defined by default. Because in most cases other libraries require `cl`, which defines them, this problem doesn't come out.

This pull request adds `(require 'cl)` to enh-ruby-mode.el.
