### PR TITLE
Fix indentation with interpolated strings in ruby 1.9.3

### DIFF
--- a/ruby/erm_buffer.rb
+++ b/ruby/erm_buffer.rb
@@ -336,8 +336,8 @@ class ErmBuffer
     def on_rbrace(tok)
       add(case @brace_stack.pop
           when :embexpr
-            indent(:r)
-            :ivar
+            indent(:e)
+            :embexpr_beg
           when :block
             indent(:e)
             :block


### PR DESCRIPTION
Commit: 2cc5fcb6762e5f3ca36e89be96fb7b6d274f6672 works in ruby 2.0.0, but it doesn't work in ruby 1.9.3,
because in Ripper in ruby 1.9.3, the right brace of an embedded expression invokes `on_rbrace`,
while in ruby 2.0.0 it invokes `on_embexpr_end`.
