### PR TITLE
Fixed indentation of leading-dot multi-line method-chains. ugh

### DIFF
--- a/ruby/erm_buffer.rb
+++ b/ruby/erm_buffer.rb
@@ -191,6 +191,7 @@ class ErmBuffer
 
     def on_period(tok)
       @mode||=:period
+      indent(:c,tok.size) if tok == "\n"
       add(:rem, tok, tok.size, false, :cont)
     end
 


### PR DESCRIPTION
Should fix #46. I'd like @vzvu3k6k to look at this and sanity check. They know this section of the code better than I do.
