### PR TITLE
Fix `while do` double indents (#37)

### DIFF
--- a/ruby/erm_buffer.rb
+++ b/ruby/erm_buffer.rb
@@ -159,10 +159,11 @@ class ErmBuffer
       Hash[list.map { |k| [k, true] }]
     end
 
-    INDENT_KW    = make_hash [:begin, :def, :case, :module, :class, :do, :for]
-    BACKDENT_KW  = make_hash [:elsif, :else, :when, :rescue, :ensure]
-    BEGINDENT_KW = make_hash [:if, :unless, :while, :until]
-    POSTCOND_KW  = make_hash [:if, :unless, :or, :and]
+    INDENT_KW          = make_hash [:begin, :def, :case, :module, :class, :do, :for]
+    BACKDENT_KW        = make_hash [:elsif, :else, :when, :rescue, :ensure]
+    BEGINDENT_KW       = make_hash [:if, :unless, :while, :until]
+    POSTCOND_KW        = make_hash [:if, :unless, :or, :and]
+    PRE_OPTIONAL_DO_KW = make_hash [:in, :while, :until]
 
     def on_op(tok)
       if @mode == :sym
@@ -202,6 +203,7 @@ class ErmBuffer
       if heredoc && heredoc.lineno == lineno()
         heredoc.restore
       end
+      @cond_stack.pop if @cond_stack.last
       @statment_start=true
       r
     end
@@ -217,6 +219,7 @@ class ErmBuffer
 
     def on_semicolon(tok)
       r=add(:kw,:semicolon,1,true)
+      @cond_stack.pop if @cond_stack.last
       @statment_start=true
       r
     end
@@ -275,12 +278,14 @@ class ErmBuffer
         len=2
       end
       @brace_stack << :embexpr
+      @cond_stack << false
       indent(:d,1)
       add(:embexpr_beg,tok,len)
     end
 
     def on_embexpr_end(tok)
       @brace_stack.pop
+      @cond_stack.pop
       indent(:e)
       add(:embexpr_beg,tok)
     end
@@ -292,6 +297,7 @@ class ErmBuffer
     end
 
     def on_lbrace(tok)
+      @cond_stack << false
       if @ident
         @brace_stack << :block
         indent(:d)
@@ -316,6 +322,7 @@ class ErmBuffer
                                else
                                  @mode
                                end]
+      @cond_stack << false
       indent(:l)
       @list_count+=1
       r=add(:rem,tok)
@@ -330,12 +337,14 @@ class ErmBuffer
       r=add(:rem,tok)
       @list_count-=1
       @ident,@mode=@ident_stack.pop
+      @cond_stack.pop
       r
     end
 
     alias on_rbracket on_rparen
 
     def on_rbrace(tok)
+      @cond_stack.pop
       add(case @brace_stack.pop
           when :embexpr
             indent(:e)
@@ -394,9 +403,24 @@ class ErmBuffer
         if sym == :end
           indent(:e)
         elsif sym == :do
-          indent(:d)
-          r=add(:kw,sym)
-          @block=:b4args
+          # `add` and `indent` must precede `@block=:b4args`.
+          # Otherwise @block is overwritten, and indentation is broken
+          # in the following code:
+          #  each do |a| # <- `|` for argument list is recognized as operator,
+          #      # <- which produces an extra indentation.
+          #  end
+
+          # `indent` precedes `add` for the compatibility of parsing result.
+
+          if @cond_stack.last
+            @cond_stack.pop
+            r = add(:kw, sym)
+          else
+            indent(:d)
+            r = add(:kw, sym)
+            @block=:b4args
+          end
+
           return r
         elsif BEGINDENT_KW.include? sym
           if @statment_start
@@ -411,6 +435,7 @@ class ErmBuffer
         elsif BACKDENT_KW.include? sym
           indent(:s) if @statment_start
         end
+        @cond_stack << true if PRE_OPTIONAL_DO_KW.include? sym
         r=add(:kw,sym,sym.size,false,last_add)
         @mode= (sym==:def || sym==:alias) && :predef
         r
@@ -452,6 +477,7 @@ class ErmBuffer
       @statment_start = true
       @indent_stack   = []
       @list_count     = 0
+      @cond_stack     = []
 
       catch :parse_complete do
         super

--- a/test/test_erm_buffer.rb
+++ b/test/test_erm_buffer.rb
@@ -233,4 +233,27 @@ puts "#{
       }
                 )
   end
+
+  def test_keyword_do_block
+    assert_equal "((13 1 13 d 7 e 10)(0 1 7 9 10)(10 7 9 10 13))",
+      parse_text(%q{
+each do
+end
+})
+  end
+
+  def test_keyword_do_cond
+    assert_equal "((20 1 20 b 2 e 17)(0 1 2 7 8 13 14 16 17)(10 2 7 8 13 14 16 17 20))",
+      parse_text(%q{
+while false do
+end
+})
+
+    assert_equal "((42 1 42 b 2 l 8 b 9 e 31 r 34 e 39)(0 1 2 7 9 14 15 20 21 23 31 34 36 38 39)(10 2 7 9 14 15 20 21 23 31 34 36 38 39 42))",
+      parse_text(%q{
+while (until false do
+       end) do
+end
+})
+  end
 end


### PR DESCRIPTION
This fixes #37. Sorry for the wait!

In this change, `@cond_stack` is used to detect if a `do` is optional or not.

``` rb
while true do # <- This `do` is optional, and does not
              #    increment the level of indentation.
end
```

`@cond_stack` is basically equivalent to `cond_stack` in parse.y of MRI, but my implementation mistakes when `until`, `while` or `for ... in` appear in a condition of `until` and the rest, like this:

``` rb
while until 1 do
        :until_body
      end do # <- ERM thinks this `do` is not optional.
  :while_body
end
```

I've once fixed this in https://github.com/vzvu3k6k/enhanced-ruby-mode/commit/6e6dc90d2808513232d82807dde7f93b456ab60f, but I postponed merging this because
- I think few want to write such a code, and I'm afraid that
  it adds bigger complexity than the problem it solves.
- As ERM thinks the `until` in the second sample code is modifier,
  the second sample is not indented properly
  whether optional `do`s are correctly detected or not.

FYI: To understand how MRI handles with `while do`, "The `do` conflict" section in [chapter 11 of Ruby Hacking Guide](http://ruby-hacking-guide.github.io/contextual.html) is helpful.
