### PR TITLE
Suppress to show syntax warning in minibuffer and ensure to highlight

### DIFF
--- a/ruby/erm.rb
+++ b/ruby/erm.rb
@@ -33,7 +33,8 @@ begin
     when :x then
       (buf || ErmBuffer).set_extra_keywords args.first.split " "
     when :c then
-      STDERR.puts "c#{buf.check_syntax}\n\n\0\0\0"
+      STDERR.puts "c"
+      STDERR.puts "#{buf.check_syntax}\n\n\0\0\0"
     when :k then
       store.rm bn
     else


### PR DESCRIPTION
When I open the below code with enh-ruby-mode,

``` ruby
require "spec_helper"

module Sample
  describe Spec do
    it "should return JSON without id" do
      task = described_class.new(id, params)
    end
  end
end
```

the below message appears in minibuffer, and the warning is not highlighted in the code.

```
error in process filter: 6: warning: assigned but unused variable - task
c
```

It looks like that the warning message is appeared before "c" prefix, in spite of the output code in `erm.rb`,

``` ruby
STDERR.puts "c#{buf.check_syntax}\n\n\0\0\0"
```

According to commit f3020c9, Ruby writes warning directly to STDOUT.

---

In this Pull Request, I modified `erm.rb` to separate outputs of "c" prefix and syntax warning.
It ensures to output "c" prefix before syntax warning.
By this change, syntax warning becomes not to appear in minibuffer, and the warning becomes to be highlighted.
