### PR TITLE
Handle lack of prog-mode in Emacs < 24

### DIFF
--- a/enh-ruby-mode.el
+++ b/enh-ruby-mode.el
@@ -227,8 +227,11 @@ the value changes.
 
 ;;; Mode:
 
+(defalias 'enh-ruby-parent-mode
+  (if (fboundp 'prog-mode) 'prog-mode 'fundamental-mode))
+
 ;;;###autoload
-(define-derived-mode enh-ruby-mode prog-mode "EnhRuby"
+(define-derived-mode enh-ruby-mode enh-ruby-parent-mode "EnhRuby"
   "Enhanced Major mode for editing Ruby code.
 
 \\{enh-ruby-mode-map}"


### PR DESCRIPTION
The code looks as if it should work in Emacs 23, apart from the use of `prog-mode`. If that's the case, here's a fix which will keep it working in Emacs 23.

If, on the other hand, there are other known incompatibilities with Emacs < 24, you should add a `;; Package-Requires: ((emacs "24"))` header to make this explicit.
