### PR TITLE
Outdent private/protected

### DIFF
--- a/enh-ruby-mode.el
+++ b/enh-ruby-mode.el
@@ -144,6 +144,11 @@ the value changes.
   "If not nil show-parens functionality from ruby-mode in 24.4 will be enabled"
   :type 'boolean :group 'enh-ruby)
 
+(defcustom enh-ruby-outdent-access-modifiers nil
+  "*Outdent public/protected/private modifiers if this is non-nil."
+  :type 'boolean :group 'enh-ruby)
+(put 'enh-ruby-outdent-access-modifiers 'safe-local-variable 'booleanp)
+
 (defconst enh-ruby-symbol-chars "a-zA-Z0-9_=?!")
 
 (defconst enh-ruby-symbol-re (concat "[" enh-ruby-symbol-chars "]"))

--- a/ruby/erm_buffer.rb
+++ b/ruby/erm_buffer.rb
@@ -291,6 +291,7 @@ class ErmBuffer
       when :period then
         add :ident, tok
       else
+        indent :s if %w(private protected public).include? tok
         if @ermbuffer.extra_keywords.include? tok then
           add :kw, tok
         else


### PR DESCRIPTION
I've been using this hack to outdent access modifiers for a long time with no problems. If you're still interested in adding it as a configurable option, here it is  :)

zenspider/enhanced-ruby-mode#58