### PR TITLE
Remove unexpected autoloads

### DIFF
--- a/enh-ruby-mode.el
+++ b/enh-ruby-mode.el
@@ -1186,13 +1186,6 @@ With ARG, do it that many times."
 
 (erm-reset)
 
-;;;###autoload
-(add-to-list 'auto-mode-alist '("\\.rb\\'" . enh-ruby-mode))
-;;;###autoload
-(add-to-list 'auto-mode-alist '("Rakefile\\'" . enh-ruby-mode))
-;;;###autoload
-(add-to-list 'auto-mode-alist '("\\.gemspec\\'" . enh-ruby-mode))
-
 (provide 'enh-ruby-mode)
 
 ;;; enh-ruby-mode.el ends here


### PR DESCRIPTION
To quote the Emacs Lisp manual:

> Simply loading a package should not change Emacs's editing
> behavior. Include a command or commands to enable and disable the
> feature, or to invoke it.

> This convention is mandatory for any file that includes custom
> definitions.  If fixing such a file to follow this convention requires
> an incompatible change, go ahead and make the incompatible change;
> don't postpone it.