### PR TITLE
Set require-final-newline correctly.

### DIFF
--- a/enh-ruby-mode.el
+++ b/enh-ruby-mode.el
@@ -253,7 +253,7 @@ the value changes.
   (setq-local paragraph-separate           paragraph-start)
   (setq-local parse-sexp-ignore-comments   t)
   (setq-local parse-sexp-lookup-properties t)
-  (setq-local require-final-newline        t)
+  (setq-local require-final-newline        mode-require-final-newline)
   (setq-local beginning-of-defun-function  'enh-ruby-beginning-of-defun)
   (setq-local end-of-defun-function        'enh-ruby-end-of-defun)
 


### PR DESCRIPTION
Right now, any user that has `global-ethan-wspace-mode` turned on faces warnings when opening a `.rb` file in Enhanced Ruby Mode. This is because `enh-ruby-mode` sets `require-final-newline` to `t` locally, which interferes with ethan-wspace mode.

This suggested fix is similar to fixes for other various modes, including Ruby Mode, [Dockerfile Mode](https://github.com/spotify/dockerfile-mode/pull/10/files), [Cucumber Mode](https://github.com/michaelklishin/cucumber.el/pull/51) and many others.

For more about the motivation, [this thread](https://github.com/glasserc/ethan-wspace/issues/22) over at ethan-wspace provides a lot of discussion and background.

Falling back to `mode-require-final-newline` is preferred since users will be able to override that setting fairly easily.