### PR TITLE
Allow text-mode style indenting in heredocs

### DIFF
--- a/enh-ruby-mode.el
+++ b/enh-ruby-mode.el
@@ -148,6 +148,13 @@ the value changes.
   "If not nil show-parens functionality from ruby-mode in 24.4 will be enabled"
   :type 'boolean :group 'enh-ruby)
 
+(defcustom enh-ruby-preserve-indent-in-heredocs nil
+  "Indent heredocs and multiline strings like text-mode.
+
+Warning: does not play well with electric-indent-mode.
+"
+  :type 'boolean :group 'enh-ruby)
+
 (defconst enh-ruby-symbol-chars "a-zA-Z0-9_=?!")
 
 (defconst enh-ruby-symbol-re (concat "[" enh-ruby-symbol-chars "]"))
@@ -645,6 +652,9 @@ modifications to the buffer."
          ((or (memq face '(font-lock-string-face enh-ruby-heredoc-delimiter-face))
               (and (eq 'font-lock-variable-name-face face)
                    (looking-at "#")))
+          (when enh-ruby-preserve-indent-in-heredocs
+            (forward-line -1)
+            (back-to-indentation))
           (current-column))
 
          (t


### PR DESCRIPTION
I'm in the process of converting to Emacs and was irritated that I couldn't control how multiline strings were indented, so I hacked this together.  It's how I expect the editor to behave, and maybe I'm not alone.

Is this useful?  Is there a better way?

**Usage**

Enable `enh-ruby-preserve-indent-in-heredocs` to activate.  Heredocs and multiline strings will get the indentation of the previous line.  Indenting the entire region therefore does not work.