### PR TITLE
Highlight additional keywords

### DIFF
--- a/enh-ruby-mode.el
+++ b/enh-ruby-mode.el
@@ -235,6 +235,94 @@ the value changes.
     table)
   "Syntax table used by enh-ruby-mode buffers.")
 
+(defconst enh-ruby-font-lock-keyword-beg-re "\\(?:^\\|[^.@$:]\\|\\.\\.\\)")
+
+(defconst enh-ruby-font-lock-keywords
+  `(;; Core methods that have required arguments.
+    (,(concat
+       enh-ruby-font-lock-keyword-beg-re
+       (regexp-opt
+        '( ;; built-in methods on Kernel
+          "at_exit"
+          "autoload"
+          "autoload?"
+          "callcc"
+          "catch"
+          "eval"
+          "exec"
+          "format"
+          "lambda"
+          "load"
+          "loop"
+          "open"
+          "p"
+          "print"
+          "printf"
+          "proc"
+          "putc"
+          "puts"
+          "require"
+          "require_relative"
+          "spawn"
+          "sprintf"
+          "syscall"
+          "system"
+          "throw"
+          "trace_var"
+          "trap"
+          "untrace_var"
+          "warn"
+          ;; keyword-like private methods on Module
+          "alias_method"
+          "attr"
+          "attr_accessor"
+          "attr_reader"
+          "attr_writer"
+          "define_method"
+          "extend"
+          "include"
+          "module_function"
+          "prepend"
+          "private_class_method"
+          "private_constant"
+          "public_class_method"
+          "public_constant"
+          "refine"
+          "using")
+        'symbols))
+     (1 (unless (looking-at " *\\(?:[]|,.)}=]\\|$\\)")
+          font-lock-builtin-face)))
+    ;; Kernel methods that have no required arguments.
+    (,(concat
+       enh-ruby-font-lock-keyword-beg-re
+       (regexp-opt
+        '("__callee__"
+          "__dir__"
+          "__method__"
+          "abort"
+          "binding"
+          "block_given?"
+          "caller"
+          "exit"
+          "exit!"
+          "fail"
+          "fork"
+          "global_variables"
+          "local_variables"
+          "private"
+          "protected"
+          "public"
+          "raise"
+          "rand"
+          "readline"
+          "readlines"
+          "sleep"
+          "srand")
+        'symbols))
+     (1 font-lock-builtin-face))
+    )
+  "Additional expressions to highlight in enh-ruby-mode.")
+
 ;;;###autoload
 (define-derived-mode enh-ruby-mode prog-mode "EnhRuby"
   "Enhanced Major mode for editing Ruby code.
@@ -263,7 +351,8 @@ the value changes.
   (set (make-local-variable 'add-log-current-defun-function)
        'enh-ruby-add-log-current-method)
 
-  (setq font-lock-defaults          '(nil t))
+  (setq-local font-lock-keywords    enh-ruby-font-lock-keywords)
+  (setq font-lock-defaults          '((enh-ruby-font-lock-keywords) nil nil))
   (setq indent-tabs-mode            enh-ruby-indent-tabs-mode)
   (setq imenu-create-index-function 'enh-ruby-imenu-create-index)
 

--- a/enh-ruby-mode.el
+++ b/enh-ruby-mode.el
@@ -346,10 +346,10 @@ the value changes.
   (setq-local beginning-of-defun-function  'enh-ruby-beginning-of-defun)
   (setq-local end-of-defun-function        'enh-ruby-end-of-defun)
 
-  (set (make-local-variable 'paragraph-start)
-       (concat "$\\|" page-delimiter))
-  (set (make-local-variable 'add-log-current-defun-function)
-       'enh-ruby-add-log-current-method)
+  (setq-local paragraph-start
+              (concat "$\\|" page-delimiter))
+  (setq-local add-log-current-defun-function
+              'enh-ruby-add-log-current-method)
 
   (setq-local font-lock-keywords    enh-ruby-font-lock-keywords)
   (setq font-lock-defaults          '((enh-ruby-font-lock-keywords) nil nil))


### PR DESCRIPTION
Highlight Kernel methods and Module private methods.  These lists are stolen from ruby-mode.