### PR TITLE
Fix indentation for leading dots (multi-line method chains)

### DIFF
--- a/ruby/erm_buffer.rb
+++ b/ruby/erm_buffer.rb
@@ -118,6 +118,7 @@ class ErmBuffer
       @list_count     = 0
       @cond_stack     = []
       @plit_stack     = []
+      @line_so_far    = []
 
       catch :parse_complete do
         super
@@ -168,6 +169,12 @@ class ErmBuffer
         end
       else
         @res[idx] = [start, pos]
+      end
+
+      if sym == :sp && tok == "\n"
+        @line_so_far = []
+      else
+        @line_so_far << [sym, tok, len]
       end
 
       throw :parse_complete if pos == @point_max
@@ -450,7 +457,16 @@ class ErmBuffer
 
     def on_period tok
       @mode ||= :period
+
       indent :c, tok.size if tok == "\n"
+
+      if @ident
+        line_so_far_str = @line_so_far.map {|(_, t, _)| t }.join
+        if line_so_far_str.strip == ""
+          indent :c, (line_so_far_str.length * -1)
+        end
+      end
+
       add :rem, tok, tok.size, false, :cont
     end
 

--- a/test/enh-ruby-mode-test.el
+++ b/test/enh-ruby-mode-test.el
@@ -74,8 +74,6 @@
    (line-should-equal " # method")))
 
 (ert-deftest enh-ruby-indent-leading-dots ()
-  ;; https://github.com/zenspider/enhanced-ruby-mode/issues/83
-  :expected-result :failed
   (with-temp-enh-rb-string
    "d.e\n.f\n"
    (indent-region (point-min) (point-max))

--- a/test/test_erm_buffer.rb
+++ b/test/test_erm_buffer.rb
@@ -269,4 +269,19 @@ a«12»=«@l»«0»{«5»a:«0» fds,
 «@l»%I'a «3»#«@d»{«0»a«@e»«3»}«@r»«0»'
 })
   end
+
+  def test_dot_indent
+    assert_parse(%q{
+«0»a.b
+
+c.
+«@c»  d
+
+g
+«@c»  .h
+
+i.j
+«@c»  .h
+})
+  end
 end


### PR DESCRIPTION
Potential fix for #83 

Tested with ruby 2.4.0