### PR TITLE
Add a missing comma between keywords

### DIFF
--- a/enh-ruby-mode.el
+++ b/enh-ruby-mode.el
@@ -7,7 +7,7 @@
 ;; Author: Geoff Jacobsen
 ;; URL: http://github.com/zenspider/Enhanced-Ruby-Mode
 ;; Created: Sep 18 2010
-;; Keywords: languages elisp, ruby
+;; Keywords: languages, elisp, ruby
 ;; Package-Requires: ((emacs "24"))
 ;; Version: 1.1.1
 


### PR DESCRIPTION
Whitout the comma, "languages elisp" was considered as a single keyword and the package was not listed in the package buffer when filtering by the "languages" keyword.