### PR TITLE
Fix misc leading dots indentation bugs

### DIFF
--- a/ruby/erm_buffer.rb
+++ b/ruby/erm_buffer.rb
@@ -171,7 +171,7 @@ class ErmBuffer
         @res[idx] = [start, pos]
       end
 
-      if sym == :sp && tok == "\n"
+      if (sym == :sp && tok == "\n") || (sym == :comment && tok.end_with?("\n"))
         @line_so_far.clear
       else
         @line_so_far << [sym, tok, len]

--- a/ruby/erm_buffer.rb
+++ b/ruby/erm_buffer.rb
@@ -393,6 +393,7 @@ class ErmBuffer
 
     def on_lbrace tok
       @cond_stack << false
+      @ident_stack << [@ident, mode]
       if @ident then
         @brace_stack << :block
         indent :d
@@ -491,7 +492,9 @@ class ErmBuffer
                :rem
              end
 
-      add type, tok
+      add(type, tok).tap do
+        @ident, @mode = @ident_stack.pop
+      end
     end
 
     def on_regexp_beg tok

--- a/test/enh-ruby-mode-test.el
+++ b/test/enh-ruby-mode-test.el
@@ -119,6 +119,13 @@
    (indent-region (point-min) (point-max))
    (buffer-should-equal "a\n  .b {}\n  .c\n")))
 
+(ert-deftest enh-ruby-indent-leading-dots-with-comment ()
+  (with-temp-enh-rb-string
+   "a\n.b # comment\n.c\n"
+
+   (indent-region (point-min) (point-max))
+   (buffer-should-equal "a\n  .b # comment\n  .c\n")))
+
 (ert-deftest enh-ruby-indent-pct-w-array ()
   (with-temp-enh-rb-string
    "words = %w[\nmoo\n]\n"

--- a/test/enh-ruby-mode-test.el
+++ b/test/enh-ruby-mode-test.el
@@ -112,6 +112,13 @@
    (indent-region (point-min) (point-max))
    (buffer-should-equal "@@b\n  .c\n  .d\n")))
 
+(ert-deftest enh-ruby-indent-leading-dots-with-block ()
+  (with-temp-enh-rb-string
+   "a\n.b {}\n.c\n"
+
+   (indent-region (point-min) (point-max))
+   (buffer-should-equal "a\n  .b {}\n  .c\n")))
+
 (ert-deftest enh-ruby-indent-pct-w-array ()
   (with-temp-enh-rb-string
    "words = %w[\nmoo\n]\n"

--- a/test/test_erm_buffer.rb
+++ b/test/test_erm_buffer.rb
@@ -292,4 +292,12 @@ i.j
 «@c»  .c
 })
   end
+
+  def test_dot_indent_with_comment
+    assert_parse(%q{
+«0»a
+«@c»  .b «4»# comment
+«@c»«0»  .c
+})
+  end
 end

--- a/test/test_erm_buffer.rb
+++ b/test/test_erm_buffer.rb
@@ -284,4 +284,12 @@ i.j
 «@c»  .h
 })
   end
+
+  def test_dot_indent_with_block
+    assert_parse(%q{
+«0»a
+«@c»  .b «@d»«10»{«0» «@e»«10»}«0»
+«@c»  .c
+})
+  end
 end


### PR DESCRIPTION
Fixes #131 and the note at the end of #128 

This adds handling for blocks and comments, but I feel like it's made worse by me not being able to understand the elisp side. Specifically, I also noticed that `do ... end` blocks messed up the indentation, but couldn't figure out what the output from ruby would have to be for elisp to indent correctly, and couldn't grok the elisp stuff to figure out what would have to change there.

PS. I really liked `debugging.md`, learned a few tricks.