### PR TITLE
Change some faces

### DIFF
--- a/ruby/erm_buffer.rb
+++ b/ruby/erm_buffer.rb
@@ -593,10 +593,12 @@ class ErmBuffer
     rem:             0,  # 'remove' TODO: make this more debuggable
     sp:              0,
     ident:           0,
+    arglist:         0,
+    block:           0,
+    op:              0,
     tstring_content: 1,  # font-lock-string-face
     const:           2,  # font-lock-type-face
     ivar:            3,  # font-lock-variable-name-face
-    arglist:         3,
     cvar:            3,
     gvar:            3,
     embexpr_beg:     3,
@@ -615,10 +617,8 @@ class ErmBuffer
     tlambda:         9,  # font-lock-function-name-face
     defname:         9,
     kw:              10, # font-lock-keyword-face
-    block:           10,
     heredoc_beg:     11,
     heredoc_end:     11,
-    op:              12, # ruby-op-face
     regexp_string:   13, # ruby-regexp-face
   }
 


### PR DESCRIPTION
Not sure how opinionated people are about these faces, but they looked bad in the theme(s) I tried, so changed them to the default face.

Change the following faces to "default"
- "arglist" (pipes around args). I thought this looked funny being
  colored like variables
- "block" (curlies around blocks). This also looked funny
- "op" (operators like ==). Themes don’t customize enh-ruby-op-face
   and the default behavior of darkening the keyword face looked
   really bad in my theme