### PR TITLE
Don't depend on ruby-mode for show-paren support

### DIFF
--- a/enh-ruby-mode.el
+++ b/enh-ruby-mode.el
@@ -1439,8 +1439,9 @@ With ARG, do it that many times."
 (defun erm--end-p ()
   "Is point directly after a block closing \"end\""
   (let ((end-pos (- (point) 3)))
-    (and (>= end-pos (point-min)) (string= "end" (buffer-substring end-pos (point))) (eq (get-text-property end-pos 'indent) 'e))))
-
+    (and (>= end-pos (point-min))
+         (string= "end" (buffer-substring end-pos (point)))
+         (eq (get-text-property end-pos 'indent) 'e))))
 
 (defun erm--advise-show-paren-data-function (orig &rest args)
   ;; First check if we are on opening ('b or 'd). We only care about
@@ -1454,7 +1455,7 @@ With ARG, do it that many times."
           (list
            opener-beg
            opener-end
-           (save-excursion (skip-syntax-backward "(w") (point))
+           (save-excursion (skip-syntax-backward ")w") (point))
            closer-end
            (not (erm--end-p)))))
     ;; Now check if we are at a closer ("end")

--- a/test/enh-ruby-mode-test.el
+++ b/test/enh-ruby-mode-test.el
@@ -292,3 +292,89 @@
    "7.times do |i|\n  puts \"number #{i+1}\"\nend\n"
 
    (toggle-to-brace)))
+
+(ert-deftest enh-ruby-paren-mode-if/open ()
+  (should-show-parens
+   "
+G|ifG foo
+  bar
+GendG"))
+
+(ert-deftest enh-ruby-paren-mode-if/close ()
+  (should-show-parens
+   "
+GifG foo
+  bar
+Gend|G"))
+
+(ert-deftest enh-ruby-paren-mode-if/mismatch ()
+  (should-show-parens
+   "
+R|ifR foo
+  bar
+R}R"))
+
+(ert-deftest enh-ruby-paren-mode-while-do/open ()
+  (should-show-parens
+   "
+G|whileG foo do
+  if bar
+    baz
+  end
+GendG"))
+
+(ert-deftest enh-ruby-paren-mode-while-do/close ()
+  (should-show-parens
+   "
+GwhileG foo do
+  if bar
+    baz
+  end
+Gend|G"))
+
+(ert-deftest enh-ruby-paren-mode-while-do/mismatch ()
+  (should-show-parens
+   "
+R|whileR foo do
+  if bar
+    baz
+  end
+RR"))
+
+(ert-deftest enh-ruby-paren-mode-begin-end ()
+  (should-show-parens
+   "
+G|beginG
+  foo
+rescue
+GendG"))
+
+(ert-deftest enh-ruby-paren-mode-if-dont-show ()
+  "point is not in right spot to highlight pairs so nothing
+should be tagged"
+  (should-show-parens
+   "
+i|f foo
+  bar
+end")
+  (should-show-parens
+   "
+if| foo
+  bar
+end")
+  (should-show-parens
+   "
+if foo
+  bar
+en|d")
+  (should-show-parens
+   "
+if foo
+  bar
+e|nd"))
+
+(ert-deftest enh-ruby-paren-mode-delegate ()
+  "delegate braces to show-paren-data-function (i.e. don't
+highlight anything)"
+  (should-show-parens
+   "foo.map |{ there }"))


### PR DESCRIPTION
We were delegating to ruby-mode's smie to get the show-paren-mode
behavior for "if"/"end" pairs, but that was causing smie to take over
indent-line-function as well.

Now erm implements its own advice around show-paren-data-function so
show-paren-mode works for "if"/"end" pairs.

Note that it is also possible to "fix" the ruby-mode dependency by
moving the smie loading code to the top of enh-ruby-mode setup so so
that erm indent-line-function overwrites the smie one. However, not
depending on ruby-mode is obviously better.

Using erm appears be much faster than smie as well (smie had noticable
lag for humongous "if"/"end" blocks).

Known differences/issues:
 - You only get show-paren highlighting when point is after "end" or
   on the first character of the opener (e.g. the "i" in "if"). I did
   this intentionally because I thought ruby-mode's behavior
   highlights things too often, and this behavior is more consistent
   with normal show-paren-mode.
 - There are some cases of invalid pairs that still highlight as valid
   due to enh-ruby-{backward,forward}-sexp bouncing to the "wrong"
   thing. I didn't attempt to fix this.

Resolves #139 