### PR TITLE
Fix infinite loop in block movement functions

### DIFF
--- a/enh-ruby-mode.el
+++ b/enh-ruby-mode.el
@@ -1111,14 +1111,18 @@ With ARG, do it that many times."
   (interactive "^p")
   (unless arg (setq arg 1))
   (let ((cont t)
-        prop)
+        prop
+        pos)
     (goto-char
      (save-excursion
        (while (>= (setq arg (1- arg)) 0)
          (while (progn
                   (enh-ruby-backward-sexp 1)
-                  (setq prop (get-text-property (point) 'indent))
-                  (not (or (eq prop 'b) (eq prop 'd))))))
+                  (setq pos (point))
+                  (setq prop (get-text-property pos 'indent))
+                  (and
+                   (> pos (point-min))
+                   (not (or (eq prop 'b) (eq prop 'd)))))))
        (point)))))
 
 (defun enh-ruby-end-of-defun (&optional arg)
@@ -1146,14 +1150,16 @@ With ARG, do it that many times."
   (interactive "^p")
   (unless arg (setq arg 1))
   (let ((cont t)
-        prop)
+        prop
+        pos)
     (goto-char
      (save-excursion
        (while (>= (setq arg (1- arg)) 0)
          (while (progn
                   (enh-ruby-forward-sexp 1)
-                  (setq prop (get-text-property (- (point) 3) 'indent))
-                  (not (eq prop 'e)))))
+                  (setq pos (point))
+                  (setq prop (get-text-property (- pos 3) 'indent))
+                  (and (< pos (point-max)) (not (eq prop 'e))))))
        (point)))))
 
 (defun enh-ruby-backward-sexp (&optional arg)


### PR DESCRIPTION
Consider the following Ruby function. The Emacs cursor is represented by the pipe character:

```ruby
RSpec.describe Foo do
  it 'bar' do
    |    
  end
end
```

By running `enh-ruby-beginning-of-block` twice, the cursor will be moved up to the first `do`. By running it a third time, the command will get stuck in an infinite loop. The same happens for `enh-ruby-end-of-block`.

This PR fixes the problem by breaking out of the loop if the cursor reaches either boundary of the buffer. With this fix, a third run will get the cursor to the very beginning of the file.

I've recently begun my deep adventures in Elisp, so I'm not sure if there's a better way to fix the issue. I would appreciate any directions :)