### PR TITLE
Handle block indentation on continued statements

### DIFF
--- a/test/enh-ruby-mode-test.el
+++ b/test/enh-ruby-mode-test.el
@@ -308,13 +308,15 @@
    (search-forward "blah")
    (should (equal "One::Two::Class#method" (enh-ruby-add-log-current-method)))))
 
+(enh-deftest enh-ruby-indent-continued-assignment ()
+  (string-should-indent "\na =\nb.map do |c|\nd(c)\nend\n"
+                        "\na =\n  b.map do |c|\n    d(c)\n  end\n"))
+
 (enh-deftest enh-ruby-indent-leading-dots-with-block-and-newlines ()
-  :expected-result :failed
   (string-should-indent "\na\n.b do\nc\nend\n.d\n\ne"
                         "\na\n  .b do\n    c\n  end\n  .d\n\ne"))
 
 (enh-deftest enh-ruby-indent-leading-dots-with-brackets-and-newlines ()
-  :expected-result :failed
   (string-should-indent "\na\n.b {\nc\n}\n.d\n\ne"
                         "\na\n  .b {\n    c\n  }\n  .d\n\ne"))
 


### PR DESCRIPTION
Issue: https://github.com/zenspider/enhanced-ruby-mode/issues/159

Before (with default settings):

```ruby
result =
  list.map do |val|
  val = do_something(val)
  do_something_else(val)
end

variable
  .method_a
  .method_b {
  do_something
  do_something_else
}
  .method_b do |e|
  e = do_something(e)
  broken?(e)
end
```

After (with default settings):

```ruby
result =
  list.map do |val|
    val = do_something(val)
    do_something_else(val)
  end

variable
  .method_a
  .method_b {
    do_something
    do_something_else
  }
  .method_b do |e|
    e = do_something(e)
    broken?(e)
  end
```