### PR TITLE
Handle indentation of arguments and newlines on continued statements

### DIFF
--- a/enh-ruby-mode.el
+++ b/enh-ruby-mode.el
@@ -936,17 +936,20 @@ not treated as modifications to the buffer."
                 opening-col             ; deep + !bounce + !hanging = match open
               (forward-line -1)
               (enh-ruby-skip-non-indentable)
-              (let ((opening-char
-                     (save-excursion (enh-ruby-backward-sexp) (char-after)))
-                    (proposed-col
-                     (enh-ruby-calculate-indent-1 pos
-                                                  (line-beginning-position))))
-                (if (< proposed-col opening-col)
-                    (- proposed-col
-                       (if (char-equal opening-char ?{)
-                           enh-ruby-hanging-brace-indent-level
-                         enh-ruby-hanging-paren-indent-level))
-                     opening-col)))))
+              (let* ((opening-char (save-excursion
+                                     (enh-ruby-backward-sexp)
+                                     (char-after)))
+                     (proposed-col (enh-ruby-calculate-indent-1 pos
+                                                                (line-beginning-position)))
+                     (chained-stmt-p (eq 'c (save-excursion (enh-ruby-backward-sexp)
+                                                            (forward-line 0)
+                                                            (get-text-property (point) 'indent))))
+                     (offset (if (char-equal opening-char ?{)
+                                 enh-ruby-hanging-brace-indent-level
+                               enh-ruby-hanging-paren-indent-level)))
+                (cond ((and chained-stmt-p (not enh-ruby-bounce-deep-indent)) (- proposed-col offset))
+                      ((< proposed-col opening-col) (- proposed-col offset))
+                      (t opening-col))))))
 
          ((or (memq face '(font-lock-string-face enh-ruby-heredoc-delimiter-face))
               (and (eq 'font-lock-variable-name-face face)
@@ -1038,7 +1041,8 @@ not treated as modifications to the buffer."
                              pc))
             (setq pc (cons (if (and (not at-eol) enh-ruby-deep-indent-paren)
                                deep-indent
-                             shallow-indent)
+                             (let ((chained-stmt-p (eq 'c start-prop)))
+                               (+ shallow-indent (if chained-stmt-p enh-ruby-hanging-paren-indent-level 0))))
                            pc)))))
 
        ((eq prop 'r)

--- a/test/enh-ruby-mode-test.el
+++ b/test/enh-ruby-mode-test.el
@@ -291,9 +291,13 @@
   (string-should-indent-like-ruby "d.e\n.f\n"))
 
 (enh-deftest enh-ruby-indent-leading-dots-with-arguments-and-newlines ()
-  :expected-result :failed
   (string-should-indent "\na\n.b(\nc\n)\n.d\n\ne"
                         "\na\n  .b(\n    c\n  )\n  .d\n\ne"))
+
+(enh-deftest enh-ruby-indent-leading-dots-with-arguments-and-newlines/bounce ()
+  (with-bounce-and-hang t nil nil
+    (string-should-indent "\na\n.b(\nc\n)\n.d\n\ne"
+                          "\na\n  .b(\n     c\n    )\n  .d\n\ne")))
 
 (enh-deftest enh-ruby-add-log-current-method/nested-modules ()
   :expected-result :failed


### PR DESCRIPTION
Issue: https://github.com/zenspider/enhanced-ruby-mode/issues/160

## With default settings

Before:

```ruby
variable
  .one
  .two(
  three,
  four
)
  .five
```

After:

```ruby

variable
  .one
  .two(
    three,
    four
  )
  .five
```

## With bounce deep indent

`(setq enh-ruby-bounce-deep-indent t)`

Before:

```ruby
variable
  .one
  .two(
  three,
  four
)
  .five
```

After:

```ruby
variable
  .one
  .two(
       three,
       four
      )
  .five
```

I'm not a fan of this style, neither I've seen it elsewhere, but I tried to keep the behavior consistent. Please let me know if this is correct @zenspider  