### PR TITLE
Fix enh-ruby-toggle-block edge cases / fix tests

### DIFF
--- a/enh-ruby-mode.el
+++ b/enh-ruby-mode.el
@@ -701,8 +701,7 @@ Warning: does not play well with command ‘electric-indent-mode’."
       (unless (looking-at "\\s *$")
         (insert "\n"))
       (indent-region beg-marker end-marker)
-      (goto-char beg-marker)
-      t)))
+      (goto-char beg-marker))))
 
 (defun enh-ruby-do-end-to-brace (orig end)
   (let (beg-marker end-marker beg-pos end-pos)
@@ -733,28 +732,28 @@ Warning: does not play well with command ‘electric-indent-mode’."
         (just-one-space -1)
         (goto-char end-marker)
         (just-one-space -1))
-      (goto-char beg-marker)
-      t)))
+      (goto-char beg-marker))))
 
 (defun enh-ruby-toggle-block ()
   "Toggle block type from do-end to braces or back.
 The block must begin on the current line or above it and end after the point.
 If the result is do-end block, it will always be multiline."
   (interactive)
-  (let ((start (point)) beg end)
-    (end-of-line)
-    (unless
-        (if (and (re-search-backward "\\(?:[^#]\\)\\({\\)\\|\\(\\_<do\\_>\\)")
-                 (progn
-                   (goto-char (or (match-beginning 1) (match-beginning 2)))
-                   (setq beg (point))
-                   (save-match-data (enh-ruby-forward-sexp))
-                   (setq end (point))
-                   (> end start)))
-            (if (match-beginning 1)
-                (enh-ruby-brace-to-do-end beg end)
-              (enh-ruby-do-end-to-brace beg end)))
-      (goto-char start))))
+  (let* ((pos (point))
+         (block-start (save-excursion
+                        (end-of-line)
+                        (while (and (not (bobp))
+                                    (not (enh-ruby-point-block-p)))
+                          (backward-char))
+                        (point)))
+         (block-end (save-excursion
+                      (goto-char block-start)
+                      (enh-ruby-forward-sexp)
+                      (point))))
+    (if (< pos block-end)
+        (if (eq (char-after block-start) ?{)
+            (enh-ruby-brace-to-do-end block-start block-end)
+          (enh-ruby-do-end-to-brace block-start block-end)))))
 
 (defun enh-ruby-imenu-create-index-in-block (prefix beg end)
   (let* ((index-alist '())
@@ -902,9 +901,18 @@ not treated as modifications to the buffer."
   "Return whether PROP is a continue property."
   (eq 'c prop))
 
+(defun enh-ruby-block-p (prop)
+  "Return whether PROP is a block property."
+  (eq 'd prop))
+
 (defun enh-ruby-point-continue-p (point)
   "Return whether property at POINT is a continue property."
   (enh-ruby-continue-p (get-text-property point 'indent)))
+
+(defun enh-ruby-point-block-p (&optional point)
+  "Return whether property at POINT is a block property."
+  (or point (setq point (point)))
+  (enh-ruby-block-p (get-text-property point 'indent)))
 
 (defun enh-ruby-calculate-indent (&optional start-point)
   "Calculate the indentation of the previous line and its level at START-POINT."

--- a/test/enh-ruby-mode-test.el
+++ b/test/enh-ruby-mode-test.el
@@ -435,34 +435,40 @@
 
 ;;; enh-ruby-toggle-block
 
-(defun toggle-to-do ()
+(defun enh-ruby-toggle-block-and-wait ()
   (enh-ruby-toggle-block)
-  (buffer-should-equal "7.times do |i|\n  puts \"number #{i+1}\"\nend\n"))
-
-(defun toggle-to-brace ()
-  (enh-ruby-toggle-block)
-  (buffer-should-equal "7.times { |i| puts \"number #{i+1}\" }\n"))
+  (erm-wait-for-parse)
+  (font-lock-fontify-buffer))
 
 (enh-deftest enh-ruby-toggle-block/both ()
   (with-temp-enh-rb-string
    "7.times { |i|\n  puts \"number #{i+1}\"\n}\n"
 
-   (toggle-to-do)
-   (toggle-to-brace)))
+   (enh-ruby-toggle-block-and-wait)
+   (buffer-should-equal "7.times do |i|\n  puts \"number #{i+1}\"\nend\n")
+   (enh-ruby-toggle-block-and-wait)
+   (buffer-should-equal "7.times { |i| puts \"number #{i+1}\" }\n")))
 
 (enh-deftest enh-ruby-toggle-block/brace ()
-  :expected-result t ; https://github.com/zenspider/enhanced-ruby-mode/issues/132
   (with-temp-enh-rb-string
    "7.times { |i|\n  puts \"number #{i+1}\"\n}\n"
 
-   (toggle-to-do)))
+   (enh-ruby-toggle-block-and-wait)
+   (buffer-should-equal "7.times do |i|\n  puts \"number #{i+1}\"\nend\n")))
 
 (enh-deftest enh-ruby-toggle-block/do ()
-  :expected-result t ; https://github.com/zenspider/enhanced-ruby-mode/issues/132
   (with-temp-enh-rb-string
    "7.times do |i|\n  puts \"number #{i+1}\"\nend\n"
 
-   (toggle-to-brace)))
+   (enh-ruby-toggle-block-and-wait)
+   (buffer-should-equal "7.times { |i| puts \"number #{i+1}\" }\n")))
+
+(enh-deftest enh-ruby-toggle-block/brace-with-inner-hash ()
+  (with-temp-enh-rb-string
+   "let(:dont_let) { { a: 1, b: 2 } }\n"
+
+   (enh-ruby-toggle-block-and-wait)
+   (buffer-should-equal "let(:dont_let) do\n  { a: 1, b: 2 } \nend\n")))
 
 (enh-deftest enh-ruby-paren-mode-if/open ()
   (should-show-parens

--- a/test/enh-ruby-mode-test.el
+++ b/test/enh-ruby-mode-test.el
@@ -440,15 +440,6 @@
   (erm-wait-for-parse)
   (font-lock-fontify-buffer))
 
-(enh-deftest enh-ruby-toggle-block/both ()
-  (with-temp-enh-rb-string
-   "7.times { |i|\n  puts \"number #{i+1}\"\n}\n"
-
-   (enh-ruby-toggle-block-and-wait)
-   (buffer-should-equal "7.times do |i|\n  puts \"number #{i+1}\"\nend\n")
-   (enh-ruby-toggle-block-and-wait)
-   (buffer-should-equal "7.times { |i| puts \"number #{i+1}\" }\n")))
-
 (enh-deftest enh-ruby-toggle-block/brace ()
   (with-temp-enh-rb-string
    "7.times { |i|\n  puts \"number #{i+1}\"\n}\n"
@@ -462,6 +453,39 @@
 
    (enh-ruby-toggle-block-and-wait)
    (buffer-should-equal "7.times { |i| puts \"number #{i+1}\" }\n")))
+
+(enh-deftest enh-ruby-toggle-block/both ()
+  (with-temp-enh-rb-string
+   "7.times { |i|\n  puts \"number #{i+1}\"\n}\n"
+
+   (enh-ruby-toggle-block-and-wait)
+   (buffer-should-equal "7.times do |i|\n  puts \"number #{i+1}\"\nend\n")
+   (enh-ruby-toggle-block-and-wait)
+   (buffer-should-equal "7.times { |i| puts \"number #{i+1}\" }\n")))
+
+(enh-deftest enh-ruby-toggle-block/does-not-trigger-when-point-is-beyond-block ()
+  (with-temp-enh-rb-string
+   "7.times { |i| puts i }\n"
+
+   (search-forward "}")
+   (enh-ruby-toggle-block-and-wait)
+   (buffer-should-equal "7.times { |i| puts i }\n")))
+
+(enh-deftest enh-ruby-toggle-block/triggers-when-point-is-at-end-of-block ()
+  (with-temp-enh-rb-string
+   "7.times { |i| puts i }\n"
+
+   (search-forward "}")
+   (backward-char)
+   (enh-ruby-toggle-block-and-wait)
+   (buffer-should-equal "7.times do |i|\n  puts i \nend\n")))
+
+(enh-deftest enh-ruby-toggle-block/with-no-block-in-buffer-does-not-fail ()
+  (with-temp-enh-rb-string
+   "puts \"test\""
+
+   (enh-ruby-toggle-block-and-wait)
+   (buffer-should-equal "puts \"test\"")))
 
 (enh-deftest enh-ruby-toggle-block/brace-with-inner-hash ()
   (with-temp-enh-rb-string


### PR DESCRIPTION
With a hash inside a brace-delimited block, `enh-ruby-toggle-block` would mistake the hash for the block and give incorrect results. This PR makes `enh-ruby-toggle-block` leverage text properties to determine where the block is, and tries to improve code clarity.

## Old behavior

Before:

```ruby
    let(:dont_let) { { a: 'a', b: 'b' } }
```

After:

```ruby
    let(:dont_let) { do
        a: 'a', b: 'b' 
      end }
```

## New behavior

After:

```ruby
    let(:dont_let) do
      { a: 'a', b: 'b' } 
    end
```

It also fixes skipped tests for `enh-ruby-toggle-block` by waiting for erm to parse the buffer and for fontification to happen before running expectations.

Closes #132