### PR TITLE
Add support for the "in" clause of Ruby 2.7

### DIFF
--- a/ruby/erm_buffer.rb
+++ b/ruby/erm_buffer.rb
@@ -133,7 +133,7 @@ class ErmBuffer
     # c - continue - period followed by return (or other way around?)
 
     INDENT_KW          = [:begin, :def, :case, :module, :class, :do, :for]
-    BACKDENT_KW        = [:elsif, :else, :when, :rescue, :ensure]
+    BACKDENT_KW        = [:elsif, :else, :when, :in, :rescue, :ensure]
     BEGINDENT_KW       = [:if, :unless, :while, :until]
     POSTCOND_KW        = [:if, :unless, :or, :and]
     PRE_OPTIONAL_DO_KW = [:in, :while, :until]


### PR DESCRIPTION
This adds support for the case-in construct introduced in Ruby 2.7.