### PR TITLE
Use \\' in auto-mode-alist regular expressions

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -28,7 +28,7 @@ Syntax checking is also performed.
 
    (add-to-list 'load-path "(path-to)/Enhanced-Ruby-Mode") ; must be added after any path containing old ruby-mode
    (autoload 'enh-ruby-mode "enh-ruby-mode" "Major mode for ruby files" t)
-   (add-to-list 'auto-mode-alist '("\\.rb$" . enh-ruby-mode))
+   (add-to-list 'auto-mode-alist '("\\.rb\\'" . enh-ruby-mode))
    (add-to-list 'interpreter-mode-alist '("ruby" . enh-ruby-mode))
 
    ;; optional
@@ -52,7 +52,7 @@ For these to work with enh-ruby-mode, you need to add hooks to the enh-ruby-mode
 == Load enh-ruby-mode for Ruby files
 
 To use enh-ruby-mode for <tt>.rb</tt> add the following to your init file:
-    (add-to-list 'auto-mode-alist '("\\.rb$" . enh-ruby-mode))
+    (add-to-list 'auto-mode-alist '("\\.rb\\'" . enh-ruby-mode))
 
 To use enh-ruby-mode for all common Ruby files and the following to your init file:
     (add-to-list 'auto-mode-alist


### PR DESCRIPTION
This follows an Emacs best practice of matching the end of the string,
not the end of a line, in auto-mode-alist.

For additional details, see:
https://www.emacswiki.org/emacs/AutoModeAlist

> Note that `\'` matches the end of a string, whereas `$` matches the
> empty string before a newline. Thus, `$` may lead to unexpected
> behavior when dealing with filenames containing newlines. (Should be
> pretty rare… ;))