### PR TITLE
Compile all "*.el" during "compile" rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,7 @@
 task :default => %w[clean test:all compile]
 
+el_files = Rake::FileList['**/*.el']
+
 def run cmd
   sh cmd do |good|
     # block prevents ruby backtrace on failure
@@ -21,8 +23,10 @@ def emacs_test args
 end
 
 desc "byte compile the project. Helps drive out warnings, but also faster."
-task :compile do
-  emacs "--batch -f batch-byte-compile enh-ruby-mode.el"
+task compile: el_files.ext('.elc')
+
+rule '.elc' => '.el' do |t|
+  emacs "--batch -f batch-byte-compile #{t.source}"
 end
 
 desc "Clean the project"

--- a/test/enh-ruby-mode-test.el
+++ b/test/enh-ruby-mode-test.el
@@ -1,5 +1,6 @@
-(load-file "helper.el")
-(load-file "../enh-ruby-mode.el")
+(eval-and-compile
+  (add-to-list 'load-path default-directory))
+(require 'helper)
 
 (local-set-key (kbd "C-c C-r")
                (lambda ()
@@ -126,11 +127,11 @@
     (string-should-indent "c = {\na: a,\nb: b\n}\n"
                           "c = {\n  a: a,\n  b: b\n}\n")))
 
-(setq input/indent-hash/trail "\nc = {a: a,\nb: b,\n c: c\n}")
-(setq input/indent-hash/hang  "\nc = {\na: a,\nb: b,\n c: c\n}")
-(setq exp/indent-hash/hang    "\nc = {\n  a: a,\n  b: b,\n  c: c\n}")
-(setq exp/indent-hash/trail   "\nc = {a: a,\n     b: b,\n     c: c\n    }")
-(setq exp/indent-hash/trail/8 "\nc = {a: a,\n             b: b,\n             c: c\n    }")
+(defconst input/indent-hash/trail "\nc = {a: a,\nb: b,\n c: c\n}")
+(defconst input/indent-hash/hang  "\nc = {\na: a,\nb: b,\n c: c\n}")
+(defconst exp/indent-hash/hang    "\nc = {\n  a: a,\n  b: b,\n  c: c\n}")
+(defconst exp/indent-hash/trail   "\nc = {a: a,\n     b: b,\n     c: c\n    }")
+(defconst exp/indent-hash/trail/8 "\nc = {a: a,\n             b: b,\n             c: c\n    }")
 
 (defmacro with-bounce-and-hang (bounce indent1 indent2 &rest body)
   `(let ((enh-ruby-bounce-deep-indent              ,bounce)
@@ -290,8 +291,8 @@
 (enh-deftest enh-ruby-indent-leading-dots/ruby ()
   (string-should-indent-like-ruby "d.e\n.f\n"))
 
-(setq leading-dot-input  "\na\n.b\n.c(\nd,\ne\n)\n.f\n")
-(setq trailing-dot-input "\na.\nb.\nc(\nd,\ne\n).\nf\n")
+(defconst leading-dot-input  "\na\n.b\n.c(\nd,\ne\n)\n.f\n")
+(defconst trailing-dot-input "\na.\nb.\nc(\nd,\ne\n).\nf\n")
 
 (enh-deftest enh-ruby-indent-leading-dots-with-arguments-and-newlines ()
   (string-should-indent leading-dot-input
@@ -435,14 +436,14 @@
 
 ;;; enh-ruby-toggle-block
 
-(setq ruby-do-block      "7.times do |i|\n  puts \"number #{i+1}\"\nend\n")
-(setq ruby-brace-block/1 "7.times { |i| puts \"number #{i+1}\" }\n")
-(setq ruby-brace-block/3 "7.times { |i|\n  puts \"number #{i+1}\"\n}\n")
+(defconst ruby-do-block      "7.times do |i|\n  puts \"number #{i+1}\"\nend\n")
+(defconst ruby-brace-block/1 "7.times { |i| puts \"number #{i+1}\" }\n")
+(defconst ruby-brace-block/3 "7.times { |i|\n  puts \"number #{i+1}\"\n}\n")
 
 (defun enh-ruby-toggle-block-and-wait ()
   (enh-ruby-toggle-block)
   (erm-wait-for-parse)
-  (font-lock-fontify-buffer))
+  (font-lock-ensure))
 
 (defun toggle-to-do ()
   (enh-ruby-toggle-block-and-wait)
@@ -465,8 +466,8 @@
   (with-temp-enh-rb-string ruby-do-block
     (toggle-to-brace)))
 
-(setq ruby-brace-block/puts "7.times { |i| puts i }\n")
-(setq ruby-do-block/puts    "7.times do |i|\n  puts i \nend\n")
+(defconst ruby-brace-block/puts "7.times { |i| puts i }\n")
+(defconst ruby-do-block/puts    "7.times do |i|\n  puts i \nend\n")
 
 (enh-deftest enh-ruby-toggle-block/does-not-trigger-when-point-is-beyond-block ()
   (with-temp-enh-rb-string ruby-brace-block/puts
@@ -481,15 +482,15 @@
     (enh-ruby-toggle-block-and-wait)
     (buffer-should-equal ruby-do-block/puts)))
 
-(setq ruby-puts "puts \"test\"")
+(defconst ruby-puts "puts \"test\"")
 
 (enh-deftest enh-ruby-toggle-block/with-no-block-in-buffer-does-not-fail ()
   (with-temp-enh-rb-string ruby-puts
     (enh-ruby-toggle-block-and-wait)
     (buffer-should-equal ruby-puts)))
 
-(setq ruby-brace/let "let(:dont_let) { { a: 1, b: 2 } }\n")
-(setq ruby-do/let    "let(:dont_let) do\n  { a: 1, b: 2 } \nend\n")
+(defconst ruby-brace/let "let(:dont_let) { { a: 1, b: 2 } }\n")
+(defconst ruby-do/let    "let(:dont_let) do\n  { a: 1, b: 2 } \nend\n")
 
 (enh-deftest enh-ruby-toggle-block/brace-with-inner-hash ()
   (with-temp-enh-rb-string ruby-brace/let

--- a/test/helper.el
+++ b/test/helper.el
@@ -1,11 +1,14 @@
 (require 'ert)
 (require 'ert-x)
 (require 'paren)                        ; for show-paren tests & helper
+(eval-and-compile
+  (add-to-list 'load-path (file-name-directory (directory-file-name default-directory))))
+(require 'enh-ruby-mode)
 
 ;; I hate this so much... Shuts up "Indenting region..." output
 (defun make-progress-reporter (&rest ignored) nil)
 
-(setq enh-tests '())
+(defvar enh-tests '())
 
 ;; turns out I had a duplicate test and it was driving me crazy. This is my fix.
 (defmacro enh-deftest (name &rest rest)
@@ -20,7 +23,7 @@
      (insert ,str)
      (enh-ruby-mode)
      (erm-wait-for-parse)
-     (font-lock-fontify-buffer)
+     (font-lock-ensure)
      (goto-char (point-min))
      (progn ,@body)))
 (put 'with-temp-enh-rb-string 'lisp-indent-function 1)
@@ -29,7 +32,7 @@
   `(with-temp-buffer
      (insert ,str)
      (ruby-mode)
-     (font-lock-fontify-buffer)
+     (font-lock-ensure)
      (goto-char (point-min))
      (progn ,@body)))
 
@@ -104,3 +107,5 @@ no erm highlighting (i.e. delgate to normal paren-mode)"
         (equal
          (erm-show-paren-data-function)
          (if tags (append tags `(,mismatch)) nil)))))))
+
+(provide 'helper)


### PR DESCRIPTION
Compiling the elisp files exposes several warnings that have now been
cleaned up. Running this regularly will help ensure the warnings don't
return.

    emacs -Q --batch -f batch-byte-compile enh-ruby-mode.el
    emacs -Q --batch -f batch-byte-compile test/enh-ruby-mode-test.el

    In toplevel form:
    test/enh-ruby-mode-test.el:22:14:Warning: reference to free variable
        ‘enh-ruby-backward-sexp-test’
    test/enh-ruby-mode-test.el:30:14:Warning: reference to free variable
        ‘enh-ruby-backward-sexp-test-inner’
    test/enh-ruby-mode-test.el:40:14:Warning: reference to free variable
        ‘enh-ruby-forward-sexp-test’
    test/enh-ruby-mode-test.el:48:14:Warning: reference to free variable
        ‘enh-ruby-up-sexp-test’
    test/enh-ruby-mode-test.el:56:14:Warning: reference to free variable
        ‘enh-ruby-end-of-defun’
    test/enh-ruby-mode-test.el:64:14:Warning: reference to free variable
        ‘enh-ruby-end-of-block’
    test/enh-ruby-mode-test.el:74:14:Warning: reference to free variable
        ‘enh-ruby-indent-array-of-strings’
    test/enh-ruby-mode-test.el:79:14:Warning: reference to free variable
        ‘enh-ruby-indent-array-of-strings-incl-first’
    test/enh-ruby-mode-test.el:84:14:Warning: reference to free variable
        ‘enh-ruby-indent-array-of-strings/deep’
    test/enh-ruby-mode-test.el:89:14:Warning: reference to free variable
        ‘enh-ruby-indent-array-of-strings-incl-first/deep’
    test/enh-ruby-mode-test.el:94:14:Warning: reference to free variable
        ‘enh-ruby-indent-array-of-strings/ruby’
    test/enh-ruby-mode-test.el:97:14:Warning: reference to free variable
        ‘enh-ruby-indent-array-of-strings-incl-first/ruby’
    test/enh-ruby-mode-test.el:101:14:Warning: reference to free variable
        ‘enh-ruby-indent-not-method’
    test/enh-ruby-mode-test.el:105:14:Warning: reference to free variable
        ‘enh-ruby-indent-hanging-period-after-parens’
    test/enh-ruby-mode-test.el:109:14:Warning: reference to free variable
        ‘enh-ruby-indent-hanging-period’
    test/enh-ruby-mode-test.el:113:14:Warning: reference to free variable
        ‘enh-ruby-indent-def-after-private’
    test/enh-ruby-mode-test.el:118:14:Warning: reference to free variable
        ‘enh-ruby-indent-def-after-private/deep’
    test/enh-ruby-mode-test.el:123:14:Warning: reference to free variable
        ‘enh-ruby-indent-hash’
    test/enh-ruby-mode-test.el:129:7:Warning: assignment to free variable
        ‘input/indent-hash/trail’
    test/enh-ruby-mode-test.el:130:7:Warning: assignment to free variable
        ‘input/indent-hash/hang’
    test/enh-ruby-mode-test.el:131:7:Warning: assignment to free variable
        ‘exp/indent-hash/hang’
    test/enh-ruby-mode-test.el:132:7:Warning: assignment to free variable
        ‘exp/indent-hash/trail’
    test/enh-ruby-mode-test.el:133:7:Warning: assignment to free variable
        ‘exp/indent-hash/trail/8’
    test/enh-ruby-mode-test.el:145:14:Warning: reference to free variable
        ‘enh-ruby-indent-hash/deep/hang/def’
    test/enh-ruby-mode-test.el:147:35:Warning: reference to free variable
        ‘enh-ruby-hanging-brace-indent-level’
    test/enh-ruby-mode-test.el:147:35:Warning: reference to free variable
        ‘enh-ruby-hanging-brace-deep-indent-level’
    test/enh-ruby-mode-test.el:148:29:Warning: reference to free variable
        ‘input/indent-hash/hang’
    test/enh-ruby-mode-test.el:149:29:Warning: reference to free variable
        ‘exp/indent-hash/hang’
    test/enh-ruby-mode-test.el:151:14:Warning: reference to free variable
        ‘enh-ruby-indent-hash/deep/bounce/hang/def’
    test/enh-ruby-mode-test.el:158:14:Warning: reference to free variable
        ‘enh-ruby-indent-hash/deep/hang/99’
    test/enh-ruby-mode-test.el:165:14:Warning: reference to free variable
        ‘enh-ruby-indent-hash/deep/hang/bil-3’
    test/enh-ruby-mode-test.el:172:14:Warning: reference to free variable
        ‘enh-ruby-indent-hash/deep/hang/bil-8’
    test/enh-ruby-mode-test.el:178:14:Warning: reference to free variable
        ‘enh-ruby-indent-hash/deep/trail/def’
    test/enh-ruby-mode-test.el:181:29:Warning: reference to free variable
        ‘input/indent-hash/trail’
    test/enh-ruby-mode-test.el:182:29:Warning: reference to free variable
        ‘exp/indent-hash/trail’
    test/enh-ruby-mode-test.el:184:14:Warning: reference to free variable
        ‘enh-ruby-indent-hash/deep/bounce/trail/def’
    test/enh-ruby-mode-test.el:190:14:Warning: reference to free variable
        ‘enh-ruby-indent-hash/deep/trail/3’
    test/enh-ruby-mode-test.el:194:29:Warning: reference to free variable
        ‘exp/indent-hash/trail/8’
    test/enh-ruby-mode-test.el:196:14:Warning: reference to free variable
        ‘enh-ruby-indent-hash/deep/bounce/trail/3’
    test/enh-ruby-mode-test.el:202:14:Warning: reference to free variable
        ‘enh-ruby-indent-hash/deep/trail/8’
    test/enh-ruby-mode-test.el:208:14:Warning: reference to free variable
        ‘enh-ruby-indent-hash/deep/bounce/trail/8’
    test/enh-ruby-mode-test.el:214:14:Warning: reference to free variable
        ‘enh-ruby-indent-bug/90/a’
    test/enh-ruby-mode-test.el:218:14:Warning: reference to free variable
        ‘enh-ruby-indent-bug/90/b’
    test/enh-ruby-mode-test.el:221:14:Warning: reference to free variable
        ‘enh-ruby-indent-hash-after-cmd’
    test/enh-ruby-mode-test.el:226:14:Warning: reference to free variable
        ‘enh-ruby-indent-hash-after-cmd/deep’
    test/enh-ruby-mode-test.el:231:14:Warning: reference to free variable
        ‘enh-ruby-indent-hash-after-cmd/ruby’
    test/enh-ruby-mode-test.el:234:14:Warning: reference to free variable
        ‘enh-ruby-indent-if-in-assignment’
    test/enh-ruby-mode-test.el:239:14:Warning: reference to free variable
        ‘enh-ruby-indent-if-in-assignment/deep’
    test/enh-ruby-mode-test.el:244:14:Warning: reference to free variable
        ‘enh-ruby-indent-leading-dots’
    test/enh-ruby-mode-test.el:248:14:Warning: reference to free variable
        ‘enh-ruby-indent-leading-dots-cvar’
    test/enh-ruby-mode-test.el:252:14:Warning: reference to free variable
        ‘enh-ruby-indent-leading-dots-cvar/ruby’
    test/enh-ruby-mode-test.el:255:14:Warning: reference to free variable
        ‘enh-ruby-indent-leading-dots-gvar’
    test/enh-ruby-mode-test.el:259:14:Warning: reference to free variable
        ‘enh-ruby-indent-leading-dots-gvar/ruby’
    test/enh-ruby-mode-test.el:262:14:Warning: reference to free variable
        ‘enh-ruby-indent-leading-dots-ident’
    test/enh-ruby-mode-test.el:266:14:Warning: reference to free variable
        ‘enh-ruby-indent-leading-dots-ident/ruby’
    test/enh-ruby-mode-test.el:269:14:Warning: reference to free variable
        ‘enh-ruby-indent-leading-dots-ivar’
    test/enh-ruby-mode-test.el:273:14:Warning: reference to free variable
        ‘enh-ruby-indent-leading-dots-ivar/ruby’
    test/enh-ruby-mode-test.el:276:14:Warning: reference to free variable
        ‘enh-ruby-indent-leading-dots-with-block’
    test/enh-ruby-mode-test.el:280:14:Warning: reference to free variable
        ‘enh-ruby-indent-leading-dots-with-block/ruby’
    test/enh-ruby-mode-test.el:283:14:Warning: reference to free variable
        ‘enh-ruby-indent-leading-dots-with-comment’
    test/enh-ruby-mode-test.el:287:14:Warning: reference to free variable
        ‘enh-ruby-indent-leading-dots-with-comment/ruby’
    test/enh-ruby-mode-test.el:290:14:Warning: reference to free variable
        ‘enh-ruby-indent-leading-dots/ruby’
    test/enh-ruby-mode-test.el:293:7:Warning: assignment to free variable
        ‘leading-dot-input’
    test/enh-ruby-mode-test.el:294:7:Warning: assignment to free variable
        ‘trailing-dot-input’
    test/enh-ruby-mode-test.el:296:14:Warning: reference to free variable
        ‘enh-ruby-indent-leading-dots-with-arguments-and-newlines’
    test/enh-ruby-mode-test.el:297:25:Warning: reference to free variable
        ‘leading-dot-input’
    test/enh-ruby-mode-test.el:300:14:Warning: reference to free variable
        ‘enh-ruby-indent-leading-dots-with-arguments-and-newlines/bounce’
    test/enh-ruby-mode-test.el:305:14:Warning: reference to free variable
        ‘enh-ruby-indent-leading-dots-with-arguments-and-newlines/ruby’
    test/enh-ruby-mode-test.el:308:14:Warning: reference to free variable
        ‘enh-ruby-indent-trailing-dots-with-arguments-and-newlines’
    test/enh-ruby-mode-test.el:309:25:Warning: reference to free variable
        ‘trailing-dot-input’
    test/enh-ruby-mode-test.el:312:14:Warning: reference to free variable
        ‘enh-ruby-indent-trailing-dots-with-arguments-and-newlines/bounce’
    test/enh-ruby-mode-test.el:317:14:Warning: reference to free variable
        ‘enh-ruby-indent-trailing-dots-with-arguments-and-newlines/ruby’
    test/enh-ruby-mode-test.el:320:14:Warning: reference to free variable
        ‘enh-ruby-add-log-current-method/nested-modules’
    test/enh-ruby-mode-test.el:327:14:Warning: reference to free variable
        ‘enh-ruby-add-log-current-method/compact-modules’
    test/enh-ruby-mode-test.el:333:14:Warning: reference to free variable
        ‘enh-ruby-indent-continued-assignment’
    test/enh-ruby-mode-test.el:337:14:Warning: reference to free variable
        ‘enh-ruby-indent-leading-dots-with-block-and-newlines’
    test/enh-ruby-mode-test.el:341:14:Warning: reference to free variable
        ‘enh-ruby-indent-leading-dots-with-brackets-and-newlines’
    test/enh-ruby-mode-test.el:345:14:Warning: reference to free variable
        ‘enh-ruby-indent-not-on-eol-opening/deep’
    test/enh-ruby-mode-test.el:350:14:Warning: reference to free variable
        ‘enh-ruby-indent-pct-w-array’
    test/enh-ruby-mode-test.el:355:14:Warning: reference to free variable
        ‘enh-ruby-indent-pct-w-array/deep’
    test/enh-ruby-mode-test.el:383:14:Warning: reference to free variable
        ‘enh-ruby-indent-trailing-dots’
    test/enh-ruby-mode-test.el:387:14:Warning: reference to free variable
        ‘enh-ruby-indent-trailing-dots/ruby’
    test/enh-ruby-mode-test.el:392:14:Warning: reference to free variable
        ‘enh-ruby-beginning-of-block’
    test/enh-ruby-mode-test.el:407:14:Warning: reference to free variable
        ‘enh-ruby-indent-for-tab-heredocs/off’
    test/enh-ruby-mode-test.el:417:14:Warning: reference to free variable
        ‘enh-ruby-indent-for-tab-heredocs/on’
    test/enh-ruby-mode-test.el:427:14:Warning: reference to free variable
        ‘enh-ruby-indent-for-tab-heredocs/unset’
    test/enh-ruby-mode-test.el:438:7:Warning: assignment to free variable
        ‘ruby-do-block’
    test/enh-ruby-mode-test.el:439:7:Warning: assignment to free variable
        ‘ruby-brace-block/1’
    test/enh-ruby-mode-test.el:440:7:Warning: assignment to free variable
        ‘ruby-brace-block/3’

    In enh-ruby-toggle-block-and-wait:
    test/enh-ruby-mode-test.el:444:4:Warning: ‘font-lock-fontify-buffer’ is for
        interactive use only; use ‘font-lock-ensure’ or ‘font-lock-flush’ instead.

    In toggle-to-do:
    test/enh-ruby-mode-test.el:449:24:Warning: reference to free variable
        ‘ruby-do-block’

    In toggle-to-brace:
    test/enh-ruby-mode-test.el:453:24:Warning: reference to free variable
        ‘ruby-brace-block/1’
    test/enh-ruby-mode-test.el:455:14:Warning: reference to free variable
        ‘enh-ruby-toggle-block/both’
    test/enh-ruby-mode-test.el:456:28:Warning: reference to free variable
        ‘ruby-brace-block/3’
    test/enh-ruby-mode-test.el:460:14:Warning: reference to free variable
        ‘enh-ruby-toggle-block/brace’
    test/enh-ruby-mode-test.el:464:14:Warning: reference to free variable
        ‘enh-ruby-toggle-block/do’
    test/enh-ruby-mode-test.el:465:28:Warning: reference to free variable
        ‘ruby-do-block’
    test/enh-ruby-mode-test.el:468:7:Warning: assignment to free variable
        ‘ruby-brace-block/puts’
    test/enh-ruby-mode-test.el:469:7:Warning: assignment to free variable
        ‘ruby-do-block/puts’
    test/enh-ruby-mode-test.el:471:14:Warning: reference to free variable
        ‘enh-ruby-toggle-block/does-not-trigger-when-point-is-beyond-block’
    test/enh-ruby-mode-test.el:472:28:Warning: reference to free variable
        ‘ruby-brace-block/puts’
    test/enh-ruby-mode-test.el:477:14:Warning: reference to free variable
        ‘enh-ruby-toggle-block/triggers-when-point-is-at-end-of-block’
    test/enh-ruby-mode-test.el:482:26:Warning: reference to free variable
        ‘ruby-do-block/puts’
    test/enh-ruby-mode-test.el:484:7:Warning: assignment to free variable
        ‘ruby-puts’
    test/enh-ruby-mode-test.el:486:14:Warning: reference to free variable
        ‘enh-ruby-toggle-block/with-no-block-in-buffer-does-not-fail’
    test/enh-ruby-mode-test.el:487:28:Warning: reference to free variable
        ‘ruby-puts’
    test/enh-ruby-mode-test.el:491:7:Warning: assignment to free variable
        ‘ruby-brace/let’
    test/enh-ruby-mode-test.el:492:7:Warning: assignment to free variable
        ‘ruby-do/let’
    test/enh-ruby-mode-test.el:494:14:Warning: reference to free variable
        ‘enh-ruby-toggle-block/brace-with-inner-hash’
    test/enh-ruby-mode-test.el:495:28:Warning: reference to free variable
        ‘ruby-brace/let’
    test/enh-ruby-mode-test.el:497:26:Warning: reference to free variable
        ‘ruby-do/let’
    test/enh-ruby-mode-test.el:499:14:Warning: reference to free variable
        ‘enh-ruby-paren-mode-if/open’
    test/enh-ruby-mode-test.el:506:14:Warning: reference to free variable
        ‘enh-ruby-paren-mode-if/close’
    test/enh-ruby-mode-test.el:513:14:Warning: reference to free variable
        ‘enh-ruby-paren-mode-if/mismatch’
    test/enh-ruby-mode-test.el:520:14:Warning: reference to free variable
        ‘enh-ruby-paren-mode-while-do/open’
    test/enh-ruby-mode-test.el:529:14:Warning: reference to free variable
        ‘enh-ruby-paren-mode-while-do/close’
    test/enh-ruby-mode-test.el:538:14:Warning: reference to free variable
        ‘enh-ruby-paren-mode-while-do/mismatch’
    test/enh-ruby-mode-test.el:547:14:Warning: reference to free variable
        ‘enh-ruby-paren-mode-begin-end’
    test/enh-ruby-mode-test.el:555:14:Warning: reference to free variable
        ‘enh-ruby-paren-mode-if-dont-show’
    test/enh-ruby-mode-test.el:579:14:Warning: reference to free variable
        ‘enh-ruby-paren-mode-delegate’

    In end of data:
    test/enh-ruby-mode-test.el:584:1:Warning: the following functions are not
        known to be defined: ert-delete-all-tests, color-darken-name, enh-deftest,
        with-temp-enh-rb-string, enh-ruby-backward-sexp, line-should-equal,
        enh-ruby-forward-sexp, enh-ruby-up-sexp, enh-ruby-end-of-defun,
        rest-of-line-should-equal, enh-ruby-end-of-block, with-deep-indent,
        string-should-indent, string-should-indent-like-ruby, should,
        enh-ruby-add-log-current-method, enh-ruby-beginning-of-block,
        buffer-should-equal, enh-ruby-toggle-block, erm-wait-for-parse,
        should-show-parens
    emacs -Q --batch -f batch-byte-compile test/helper.el

    In toplevel form:
    test/helper.el:8:7:Warning: assignment to free variable ‘enh-tests’

    In enh-deftest:
    test/helper.el:12:18:Warning: reference to free variable ‘enh-tests’
    test/helper.el:14:32:Warning: assignment to free variable ‘enh-tests’

    In string-should-indent:
    test/helper.el:49:39:Warning: ‘font-lock-fontify-buffer’ is for interactive
        use only; use ‘font-lock-ensure’ or ‘font-lock-flush’ instead.

    In string-should-indent-like-ruby:
    test/helper.el:54:41:Warning: ‘font-lock-fontify-buffer’ is for interactive
        use only; use ‘font-lock-ensure’ or ‘font-lock-flush’ instead.
    test/helper.el:55:41:Warning: ‘font-lock-fontify-buffer’ is for interactive
        use only; use ‘font-lock-ensure’ or ‘font-lock-flush’ instead.

    In should-show-parens:
    test/helper.el:101:8:Warning: ‘font-lock-fontify-buffer’ is for interactive
        use only; use ‘font-lock-ensure’ or ‘font-lock-flush’ instead.

    In end of data:
    test/helper.el:107:1:Warning: the following functions are not known to be
        defined: enh-ruby-mode, erm-wait-for-parse, erm-show-paren-data-function