### PR TITLE
Edit docstrings to pass aggressive byte-compile checking.

### DIFF
--- a/enh-ruby-mode.el
+++ b/enh-ruby-mode.el
@@ -205,7 +205,9 @@ Warning: does not play well with command ‘electric-indent-mode’."
   :group 'enh-ruby)
 
 (defvar enh-ruby-use-ruby-mode-show-parens-config nil
-  "This flag has no effect anymore as ERM supports command ‘show-paren-mode’ directly.")
+  "OBSOLETE.
+This flag has no effect anymore as ERM supports
+command ‘show-paren-mode’ directly.")
 
 (make-obsolete-variable 'enh-ruby-use-ruby-mode-show-parens-config nil "2018-04-03")
 
@@ -653,7 +655,9 @@ Warning: does not play well with command ‘electric-indent-mode’."
     (enh-ruby-fontify-buffer)))
 
 (defun enh-ruby-local-enable-extra-keywords ()
-  "If the variable `ruby-extra-keywords' is buffer local then enable the keywords for current buffer."
+  "Conditionally enable keywords for current buffer.
+If the variable `ruby-extra-keywords' is buffer local,
+then enable the keywords for current buffer."
   (when (local-variable-p 'enh-ruby-extra-keywords)
       (process-send-string (erm-ruby-get-process)
                            (concat "x"
@@ -1150,7 +1154,10 @@ not treated as modifications to the buffer."
     messages))
 
 (defun enh-ruby-find-error (&optional warnings)
-  "Search back, then forward for a syntax error/warning. Display contents in mini-buffer. Optional WARNINGS will highlight warnings instead of errors. (I think)."
+  "Search back, then forward for a syntax error/warning.
+Display contents in mini-buffer.
+
+Optional WARNINGS will highlight warnings instead of errors. (I think)."
   (interactive "^P")
   (let (overlays
         overlay
@@ -1663,17 +1670,20 @@ stuff by changing vars over and over."
         (enh-ruby--variable-values pairs)))
 
 (defun enh-ruby-add-file-local-variables ()
-  "Insert all currently customized variables for this mode as file-local variables. This is mainly for providing a complete example in a bug report."
+  "Insert all currently customized variables for this mode as file-local variables.
+This is mainly for providing a complete example in a bug report."
   (interactive)
   (enh-ruby--add-fl-variables (enh-ruby--changed-vars-with "enh-ruby")))
 
 (defun enh-ruby-add-all-file-local-variables ()
-  "Insert all variables for this mode as file-local variables. This is mainly for providing a complete example in a bug report."
+  "Insert all variables for this mode as file-local variables.
+This is mainly for providing a complete example in a bug report."
   (interactive)
   (enh-ruby--add-fl-variables (enh-ruby--all-vars-with "enh-ruby")))
 
 (defun enh-ruby-add-indent-file-local-variables ()
-  "Insert all indent variables for this mode as file-local variables. This is mainly for providing a complete example in a bug report."
+  "Insert all indent variables for this mode as file-local variables.
+This is mainly for providing a complete example in a bug report."
   (interactive)
   (enh-ruby--add-fl-variables (enh-ruby--all-vars-with "enh-ruby.*indent")))
 


### PR DESCRIPTION
Emacs 28 is aggressive about byte-compiling packages. These changes eliminate all the warnings for "docstring longer than 80 characters".