### PR TITLE
Indentation support for endless methods

### DIFF
--- a/ruby/erm_buffer.rb
+++ b/ruby/erm_buffer.rb
@@ -49,6 +49,8 @@ class ErmBuffer
         case parser.mode
         when :predef, :expdef then
           # do nothing
+        when :def
+          parser.mode = :postdef
         else
           parser.mode = nil
         end
@@ -514,9 +516,11 @@ class ErmBuffer
     end
 
     def on_lparen tok
+      debug_on tok
       newmode = case mode
                 when :def then
                   self.mode = nil
+                  :def
                 when :predef then
                   self.mode = :expdef
                   :predef
@@ -558,6 +562,9 @@ class ErmBuffer
             when :def, :predef then
               add :ident, tok
             else
+              if mode == :postdef && tok == '='
+                indent :e
+              end
               add :op, tok, tok.size, false, :cont
             end
           end

--- a/test/enh-ruby-mode-test.el
+++ b/test/enh-ruby-mode-test.el
@@ -112,6 +112,21 @@
   (string-should-indent-like-ruby
    ":a\nb\n.c"))
 
+(enh-deftest enh-ruby-indent-def-endless ()
+  (with-deep-indent nil
+   (string-should-indent "class Foo\ndef foo = z\ndef bar = y\nend\n"
+                         "class Foo\n  def foo = z\n  def bar = y\nend\n")))
+
+(enh-deftest enh-ruby-indent-def-endless/params ()
+  (with-deep-indent nil
+   (string-should-indent "class Foo\ndef foo(a) = z\ndef bar = y\nend\n"
+                         "class Foo\n  def foo(a) = z\n  def bar = y\nend\n")))
+
+(enh-deftest enh-ruby-indent-def-endless/args-forward ()
+  (with-deep-indent nil
+   (string-should-indent "class Foo\ndef foo(...) = z\ndef bar = y\nend\n"
+                         "class Foo\n  def foo(...) = z\n  def bar = y\nend\n")))
+
 (enh-deftest enh-ruby-indent-def-after-private ()
   (with-deep-indent nil
    (string-should-indent "class Foo\nprivate def foo\nx\nend\nend\n"

--- a/test/test_erm_buffer.rb
+++ b/test/test_erm_buffer.rb
@@ -147,6 +147,23 @@ p a
 })
   end
 
+  def test_endless_def
+    assert_parse(%q{
+«@b»«10»def«0» «10»self«0».«9»m«0» «@e»«12»=«0» ident
+
+«@b»«10»def«0» «9»m«0» «@e»«12»=«0» ident
+
+«@b»«10»def«0» «9»m«@l»«0»(a«@r») «@e»«12»=«0» ident
+
+«@b»«10»def«0» «9»m«@l»«0»(«12»*«0»a, «12»**«0»k, «12»&«0»b«@r») «@e»«12»=«0» ident
+
+«@b»«10»def«0» «9»m«@l»«0»(«12»...«@r»«0») «@e»«12»=«0» ident
+
+«@b»«10»def«0» «9»m«0» «@e»«12»=«0»
+«@c»  ident
+})
+  end
+
   def test_heredoc_followed_by_if_arg
     assert_parse(%q{
 «0»bob«@l»(«11»<<-END«0», «@b»«10»if«0» a


### PR DESCRIPTION
Fixes #186

I'm sure there is a much better way to do this. I wonder if somehow `on_bodystmt` can be used for all methods. I tried to use it but if I write the indent marker in it it ends up on the next line and that doesn't work. I don't fully understand how any of this works, so this is really just a brute force attempt. But hey, it has tests and passes all the existing ones. 

Let me know if there is any thing I can do to improve this. Thanks!

**edit**: I've pushed a few revisions since originally opening this. It seems to work well and is not as hacky as the original method I attempted.